### PR TITLE
Update contract.js

### DIFF
--- a/dependencies/lobby/index.js
+++ b/dependencies/lobby/index.js
@@ -9,7 +9,7 @@ const DEPLOY_DIR_PATH = "/deploy";
 const STATUS_FLAG = `${CONTRACT_DIR_PATH}/status.flag`;
 const INSTANCE_INFO_FILE = `${CONTRACT_DIR_PATH}/instance.json`;
 const HP_CFG_DIR_PATH = `${CONTRACT_DIR_PATH}/cfg`;
-const PEER_LIST_SIZE = 20;
+const PEER_LIST_SIZE = 10;
 
 function readHpCfg(path = null) {
     return JSON.parse(fs.readFileSync(path || `${HP_CFG_DIR_PATH}/hp.cfg`));

--- a/src/contract.js
+++ b/src/contract.js
@@ -30,7 +30,7 @@ const NUM_HASHES = TOTAL_FILE_SIZE / WRITE_INTERVAL;
 const SODIUM_FREQUENCY = 200;
 const PWHASH_MEM_LIMIT = 300 * 1024 * 1024;
 
-const OPINION_WRITE_WAIT = 30000;
+const OPINION_WRITE_WAIT = 44000;
 
 const formatTimestamp = () => {
     return new Date().toLocaleTimeString('en-GB');


### PR DESCRIPTION
Increase OPINION_WRITE_WAIT to 44000 from 30000. To remain in time with consensus this time must be less than 45000ms.

This change allow more time for POW to be completed and proposals uploaded, given the network size, network topology and messaging.